### PR TITLE
【分類情報管理：MVC①】

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -28,4 +28,7 @@ public class UrlConsts {
 
 	// 認証不要画面
 	public static final String[] NO_AUTHENTICATION = {LOGIN, AUTHENTICATE};
+
+	// 分割情報管理画面
+	public static final String CATEGORIZED_INFO_MNG = "/admin/categorizedInfoMng";
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategorizedInfoMngController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategorizedInfoMngController.java
@@ -1,0 +1,27 @@
+package com.digitalojt.web.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import com.digitalojt.web.consts.UrlConsts;
+
+/**
+ * 分割情報管理画面コントローラークラス
+ * 
+ * @author Kazuma Kuroki
+ *
+ */
+@Controller
+public class CategorizedInfoMngController extends AbstractController {
+
+	/**
+	 * 初期表示
+	 * 
+	 * @return String(path)
+	 */
+	@GetMapping(UrlConsts.CATEGORIZED_INFO_MNG)
+	public String index() {
+
+		return "admin/categorizedInfoMng/index";
+	}
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categorizedInfoMng/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categorizedInfoMng/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  th:replace="~{layout/template :: layout(~{::title},~{::body/content()})}"
+>
+  <head>
+    <title>InvenTrack</title>
+  </head>
+
+  <body>
+	<p>Hello World</p>
+  </body>
+</html>

--- a/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/navbar.html
@@ -26,7 +26,7 @@
 				<a class="nav-link" th:href="@{'/admin/stockList'}">
 					<span>在庫一覧</span>
 				</a>
-				<a class="nav-link" th:href="@{'/admin/stockList'}">
+				<a class="nav-link" th:href="@{'/admin/categorizedInfoMng'}">
 					<span>分類情報管理</span>
 				</a>
 				<a class="nav-link" th:href="@{'/admin/centerInfo'}">


### PR DESCRIPTION
## 概要
分類情報管理画面の初期表示を作成

## 処理内容
・メニューバーの「分類情報管理」押下時に、分類情報管理画面を初期表示の状態で出力する。

レビュー宜しくお願いいたします。
