### PR TITLE
【分類情報管理：MVC③】分類情報管理画面に検索フォーム追加、入力チェック追加

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategorizedInfoMngController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategorizedInfoMngController.java
@@ -2,13 +2,20 @@ package com.digitalojt.web.controller;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 
 import com.digitalojt.web.consts.ItemCategory;
 import com.digitalojt.web.consts.UrlConsts;
+import com.digitalojt.web.dto.SearchForm;
+
+import jakarta.validation.Valid;
 
 /**
  * 分割情報管理画面コントローラークラス
@@ -19,6 +26,9 @@ import com.digitalojt.web.consts.UrlConsts;
 @Controller
 public class CategorizedInfoMngController extends AbstractController {
 
+	// 分類名リスト初期化
+	private List<String> categoryList = new ArrayList<>();
+
 	/**
 	 * 初期表示
 	 * 
@@ -28,20 +38,58 @@ public class CategorizedInfoMngController extends AbstractController {
 	@GetMapping(UrlConsts.CATEGORIZED_INFO_MNG)
 	public String index(Model model) {
 
-		List<String> CategoryList = new ArrayList<>();
-		CategoryList.add(ItemCategory.FRAME);
-		CategoryList.add(ItemCategory.PROPELLER);
-		CategoryList.add(ItemCategory.ELECTRIC_MOTOR);
-		CategoryList.add(ItemCategory.ELECTRONIC_SPEED_CONTROLLER);
-		CategoryList.add(ItemCategory.BATTERY);
-		CategoryList.add(ItemCategory.FLIGHT_CONTROLLER);
-		CategoryList.add(ItemCategory.REMOTE_CONTROLLER);
-		CategoryList.add(ItemCategory.RECEIVER);
-		CategoryList.add(ItemCategory.GPS_MODULE);
-		CategoryList.add(ItemCategory.CAMERA_SENSOR);
+		// 分類名リストが空だったら分類名をリストに格納
+		if (categoryList.isEmpty()) {
+			inputCategoryList();
+		}
 
-		model.addAttribute("itemCategory", CategoryList);
+		model.addAttribute("itemCategory", categoryList);
+		model.addAttribute("searchForm", new SearchForm());
 
 		return "admin/categorizedInfoMng/index";
+	}
+
+	/**
+	 * 分類名検索
+	 * 
+	 * @param searchForm 検索用フォーム
+	 * @param result 入力チェック
+	 * @param model モデル
+	 * @return
+	 */
+	@PostMapping("/searchCategory")
+	public String searchCategory(@Valid @ModelAttribute("searchForm") SearchForm searchForm,
+			BindingResult result, Model model) {
+		
+		if(result.hasErrors()) {
+			model.addAttribute("itemCategory", categoryList);
+
+			return "admin/categorizedInfoMng/index";
+		}
+
+		String keyword = searchForm.getSearchKeyword();
+		List<String> filteredCategories = categoryList.stream()
+				.filter(category -> category.contains(keyword))
+				.collect(Collectors.toList());
+
+		// 検索結果をModelに格納
+		model.addAttribute("itemCategory", filteredCategories);
+		return "admin/categorizedInfoMng/index";
+	}
+
+	/**
+	 * 分類名リスト格納
+	 */
+	public void inputCategoryList() {
+		categoryList.add(ItemCategory.FRAME);
+		categoryList.add(ItemCategory.PROPELLER);
+		categoryList.add(ItemCategory.ELECTRIC_MOTOR);
+		categoryList.add(ItemCategory.ELECTRONIC_SPEED_CONTROLLER);
+		categoryList.add(ItemCategory.BATTERY);
+		categoryList.add(ItemCategory.FLIGHT_CONTROLLER);
+		categoryList.add(ItemCategory.REMOTE_CONTROLLER);
+		categoryList.add(ItemCategory.RECEIVER);
+		categoryList.add(ItemCategory.GPS_MODULE);
+		categoryList.add(ItemCategory.CAMERA_SENSOR);
 	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/dto/SearchForm.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/dto/SearchForm.java
@@ -1,0 +1,22 @@
+package com.digitalojt.web.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public class SearchForm {
+
+	@NotEmpty(message = "※分類名を入力してください。")
+	@Size(max = 15, message = "※分類名は1文字以上15文字以内で入力してください。")
+	@Pattern(regexp = "^[^ {}()'*;$=&#]*$", message = "※不正な入力を検知しました。")
+	private String searchKeyword;
+
+	public String getSearchKeyword() {
+		return searchKeyword;
+	}
+
+	public void setSearchKeyword(String searchKeyword) {
+		this.searchKeyword = searchKeyword;
+	}
+}
+

--- a/DroneInventorySystem/src/main/resources/static/css/style.css
+++ b/DroneInventorySystem/src/main/resources/static/css/style.css
@@ -1,8 +1,74 @@
 @charset "UTF-8";
+
+.search {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 10px;
+	width: 100%;
+	max-width: 600px;
+	margin-left: auto;
+	margin-right: auto;
+	padding-right: 100px;
+	margin-bottom: 20px;
+}
+
+.filter {
+	font-size: 20px;
+	gap: 10px;
+	margin: 0;
+	text-decoration: underline;
+	text-align: center;
+	width: auto;
+}
+
+.categories {
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+	align-items: center;
+}
+
+.form {
+	display: flex;
+}
+
+.form p {
+	margin-top: auto;
+	margin-bottom: auto;
+	margin-left: 50px;
+	padding-right: 10px;
+	text-align: left;
+	white-space: nowrap;
+}
+
+form {
+  display: flex;
+  gap: 10px;
+  padding-left: 20px;
+  margin-top: auto;
+  margin-bottom: auto;
+  max-width: 600px;
+  align-items: center;
+}
+
+button {
+	height: 35px;
+	white-space: nowrap;
+	background-color: papayawhip;
+	width: 70px;
+}
+
+.error-msg {
+	color: red;
+	font-size: 14px;
+}
+
 .table-body {
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
 }
 
 .table-center {
@@ -14,3 +80,4 @@
 .table-center td {
 	text-align: center;
 }
+

--- a/DroneInventorySystem/src/main/resources/static/js/script.js
+++ b/DroneInventorySystem/src/main/resources/static/js/script.js
@@ -1,0 +1,15 @@
+function filterTable() {
+	const searchTerm = document.getElementById('searchBox').value.toLowerCase(); // 検索ボックスの値を取得
+	const rows = document.querySelectorAll('#dataTable tbody tr'); // 表の行を取得
+	
+	rows.forEach(row => {
+		const cell = row.querySelector('td'); // 各行の分類名を取得
+		const text = cell.textContent.toLowerCase(); // 小文字にして比較
+		
+		if (text.includes(searchTerm)) {
+			row.style.display = ''; // 一致した場合は行を表示
+		} else {
+			row.style.display = 'none'; // 一致しない場合は行を非表示
+		}
+	});
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categorizedInfoMng/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categorizedInfoMng/index.html
@@ -11,17 +11,34 @@
 		<div class="card shadow mb-4">
 			<div class="card-header py-3">
 				<h6 class="m-0 font-weight-bold text-primary">分類情報管理</h6>
-			</div>
-			
-			<div class="card-body">
-				<div class="table-body">
-					<table class="table table-bordered table-center" cellspacing="0">
-						<tbody>
-							<tr th:each="item : ${itemCategory}">
-								<td th:text="${item}"></td>
-							</tr>
-						</tbody>
-					</table>
+				<div class="card-body">
+					<!-- 検索条件部分 -->
+					<div class="search">
+						<div class="categories">
+							<div class="form">
+								<p class="filter">検索条件</p>
+								<p>分類名</p>
+								<form th:action="@{/searchCategory}" th:object="${searchForm}" method="post">
+									<input type="text" id="searchKeyword" th:field="*{searchKeyword}" />
+									<button type="submit">検索</button>
+								</form>
+							</div>
+							<!-- エラーメッセージ表示 -->
+							<div th:if="${#fields.hasErrors('searchForm.searchKeyword')}" class="error-msg">
+								<p th:errors="*{searchForm.searchKeyword}"></p>
+							</div>
+						</div>
+					</div>
+					<!-- 表部分 -->
+					<div class="table-body">
+						<table class="table table-bordered table-center" id="dataTable" cellspacing="0">
+							<tbody>
+								<tr th:each="item : ${itemCategory}">
+									<td th:text="${item}"></td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/DroneInventorySystem/src/main/resources/templates/layout/template.html
+++ b/DroneInventorySystem/src/main/resources/templates/layout/template.html
@@ -24,6 +24,7 @@
       media="screen, projection"
     />
     <link rel="stylesheet" th:href="@{/css/style.css}">
+    <script type="text/javascript" th:src="@{/js/script.js}"></script>
   </head>
 
   <body>


### PR DESCRIPTION
## 概要

分類情報管理画面に検索フォームを追加し、下のカテゴリーの表と一致する文字列があればその文字列を返却する処理を実装。
検索フォームに不正な値が入力された場合の入力チェックを実装。

## 実装方針・詳細

- 実装方針・詳細 1
　検索フォーム用にSearchFormクラスを追加。
　検索フォームで入力される文字に対してValidationで入力チェックを行う。

- 実装方針・詳細 2
　分類名をリストに格納する処理を別メソッドに分ける。
　分類情報管理画面controllerに分類名検索用のメソッドを追加。
　Validationでエラーがある場合はエラーメッセージをモデルに詰めて表示、リストを再表示。
　フォームに入力した値とリストにある文字列が同じ場合、その文字列のみを抽出して表示。

- 実装方針・詳細 3
　分類情報管理画面のHTMLにて、エラーメッセージ表示、検索フォーム、検索ボタン、フォーム送信などを追加。
　CSSも合わせて適用。
