### PR TITLE
【分類情報管理：DB操作 ①】分類情報管理画面の初期表示に出力する分類名データをDBから取得

### DIFF
--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/consts/UrlConsts.java
@@ -9,7 +9,7 @@ package com.digitalojt.web.consts;
 public class UrlConsts {
 
 	// ログイン
-	public static final String LOGIN = "/login";
+	public static final String LOGIN = "/";
 
 	// 認証
 	public static final String AUTHENTICATE = "/authenticate";

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategorizedInfoMngController.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/controller/CategorizedInfoMngController.java
@@ -2,20 +2,16 @@ package com.digitalojt.web.controller;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PostMapping;
 
-import com.digitalojt.web.consts.ItemCategory;
 import com.digitalojt.web.consts.UrlConsts;
 import com.digitalojt.web.dto.SearchForm;
-
-import jakarta.validation.Valid;
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.service.CategorizedInfoMngService;
 
 /**
  * 分割情報管理画面コントローラークラス
@@ -26,8 +22,12 @@ import jakarta.validation.Valid;
 @Controller
 public class CategorizedInfoMngController extends AbstractController {
 
-	// 分類名リスト初期化
-	private List<String> categoryList = new ArrayList<>();
+	/** 分類情報テーブル リポジトリー */
+	@Autowired
+	private CategorizedInfoMngService service;
+
+	/** 分類名リスト初期化 */
+	private List<CategoryInfo> categoryList = new ArrayList<>();
 
 	/**
 	 * 初期表示
@@ -40,7 +40,8 @@ public class CategorizedInfoMngController extends AbstractController {
 
 		// 分類名リストが空だったら分類名をリストに格納
 		if (categoryList.isEmpty()) {
-			inputCategoryList();
+			// 分類情報管理画面に表示するデータを取得
+			categoryList = service.getCategoryInfoData();
 		}
 
 		model.addAttribute("itemCategory", categoryList);
@@ -49,47 +50,47 @@ public class CategorizedInfoMngController extends AbstractController {
 		return "admin/categorizedInfoMng/index";
 	}
 
-	/**
-	 * 分類名検索
-	 * 
-	 * @param searchForm 検索用フォーム
-	 * @param result 入力チェック
-	 * @param model モデル
-	 * @return
-	 */
-	@PostMapping("/searchCategory")
-	public String searchCategory(@Valid @ModelAttribute("searchForm") SearchForm searchForm,
-			BindingResult result, Model model) {
-		
-		if(result.hasErrors()) {
-			model.addAttribute("itemCategory", categoryList);
+	//	/**
+	//	 * 分類名検索
+	//	 * 
+	//	 * @param searchForm 検索用フォーム
+	//	 * @param result 入力チェック
+	//	 * @param model モデル
+	//	 * @return
+	//	 */
+	//	@PostMapping("/searchCategory")
+	//	public String searchCategory(@Valid @ModelAttribute("searchForm") SearchForm searchForm,
+	//			BindingResult result, Model model) {
+	//		
+	//		if(result.hasErrors()) {
+	//			model.addAttribute("itemCategory", categoryList);
+	//
+	//			return "admin/categorizedInfoMng/index";
+	//		}
+	//
+	//		String keyword = searchForm.getSearchKeyword();
+	//		List<CategoryInfo> filteredCategories = categoryList.stream()
+	//				.filter(category -> category.contains(keyword))
+	//				.collect(Collectors.toList());
+	//
+	//		// 検索結果をModelに格納
+	//		model.addAttribute("itemCategory", filteredCategories);
+	//		return "admin/categorizedInfoMng/index";
+	//	}
 
-			return "admin/categorizedInfoMng/index";
-		}
-
-		String keyword = searchForm.getSearchKeyword();
-		List<String> filteredCategories = categoryList.stream()
-				.filter(category -> category.contains(keyword))
-				.collect(Collectors.toList());
-
-		// 検索結果をModelに格納
-		model.addAttribute("itemCategory", filteredCategories);
-		return "admin/categorizedInfoMng/index";
-	}
-
-	/**
-	 * 分類名リスト格納
-	 */
-	public void inputCategoryList() {
-		categoryList.add(ItemCategory.FRAME);
-		categoryList.add(ItemCategory.PROPELLER);
-		categoryList.add(ItemCategory.ELECTRIC_MOTOR);
-		categoryList.add(ItemCategory.ELECTRONIC_SPEED_CONTROLLER);
-		categoryList.add(ItemCategory.BATTERY);
-		categoryList.add(ItemCategory.FLIGHT_CONTROLLER);
-		categoryList.add(ItemCategory.REMOTE_CONTROLLER);
-		categoryList.add(ItemCategory.RECEIVER);
-		categoryList.add(ItemCategory.GPS_MODULE);
-		categoryList.add(ItemCategory.CAMERA_SENSOR);
-	}
+	//	/**
+	//	 * 分類名リスト格納
+	//	 */
+	//	public void inputCategoryList() {
+	//		categoryList.add(ItemCategory.FRAME);
+	//		categoryList.add(ItemCategory.PROPELLER);
+	//		categoryList.add(ItemCategory.ELECTRIC_MOTOR);
+	//		categoryList.add(ItemCategory.ELECTRONIC_SPEED_CONTROLLER);
+	//		categoryList.add(ItemCategory.BATTERY);
+	//		categoryList.add(ItemCategory.FLIGHT_CONTROLLER);
+	//		categoryList.add(ItemCategory.REMOTE_CONTROLLER);
+	//		categoryList.add(ItemCategory.RECEIVER);
+	//		categoryList.add(ItemCategory.GPS_MODULE);
+	//		categoryList.add(ItemCategory.CAMERA_SENSOR);
+	//	}
 }

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/entity/CategoryInfo.java
@@ -1,0 +1,48 @@
+package com.digitalojt.web.entity;
+
+import java.sql.Timestamp;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * 分類名情報Entity
+ * 
+ * @author Kazuma Kuroki
+ *
+ */
+@Data
+@Getter
+@Setter
+@Entity
+public class CategoryInfo {
+
+	/**
+	 * カテゴリーID
+	 */
+	@Id
+	private int categoryId;
+	
+	/**
+	 * 分類名
+	 */
+	private String CategoryName;
+	
+	/**
+	 * 論理削除フラグ
+	 */
+	private String deleteFlag;
+
+	/**
+	 * 更新日
+	 */
+	private Timestamp updateDate;
+
+	/**
+	 * 登録日
+	 */
+	private Timestamp createDate;
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategorizedInfoMngRepository.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/repository/CategorizedInfoMngRepository.java
@@ -1,0 +1,17 @@
+package com.digitalojt.web.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.digitalojt.web.entity.CategoryInfo;
+
+/**
+ * 分類名情報テーブルリポジトリー
+ *
+ * @author Kazuma Kuroki
+ * 
+ */
+@Repository
+public interface CategorizedInfoMngRepository extends JpaRepository<CategoryInfo, Integer> {
+
+}

--- a/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategorizedInfoMngService.java
+++ b/DroneInventorySystem/src/main/java/com/digitalojt/web/service/CategorizedInfoMngService.java
@@ -1,0 +1,38 @@
+package com.digitalojt.web.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.digitalojt.web.entity.CategoryInfo;
+import com.digitalojt.web.repository.CategorizedInfoMngRepository;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 分類情報管理画面のサービスクラス
+ *
+ * @author Kazuma Kuroki
+ * 
+ */
+@Service
+@RequiredArgsConstructor
+public class CategorizedInfoMngService {
+
+	/** 分類情報テーブル リポジトリー */
+	private final CategorizedInfoMngRepository repository;
+
+	/**
+	 * 分類名情報を全件検索で取得
+	 * 
+	 * @return 分類名情報全件データ
+	 */
+	public List<CategoryInfo> getCategoryInfoData() {
+
+		// 分類名情報作成
+		List<CategoryInfo> categoryList = repository.findAll();
+
+		return categoryList;
+	}
+
+}

--- a/DroneInventorySystem/src/main/resources/templates/admin/categorizedInfoMng/index.html
+++ b/DroneInventorySystem/src/main/resources/templates/admin/categorizedInfoMng/index.html
@@ -34,7 +34,7 @@
 						<table class="table table-bordered table-center" id="dataTable" cellspacing="0">
 							<tbody>
 								<tr th:each="item : ${itemCategory}">
-									<td th:text="${item}"></td>
+									<td th:text="${item.CategoryName}"></td>
 								</tr>
 							</tbody>
 						</table>


### PR DESCRIPTION
## 概要

分類情報管理画面の初期表示で出力する分類名データを定数クラスから取得するのではなく、データベースから取得するよう実装。

## 実装方針・詳細

- 実装方針・詳細 1
　データベースから取得するため、Entityクラス、Serviceクラス、Repositoryクラスを作成。
- 実装方針・詳細 2
　RepositoryクラスでJpaRepositoryクラスを継承し、findAllメソッドをServiceクラスで利用。
　作成したEntityクラスを受け皿として型指定。
- 実装方針・詳細 3
　Serviceクラスのメソッド内でRepositoryクラスのfindAllメソッド呼び出し。
　戻り値をControllerクラスに渡す。
- 実装方針・詳細 4
　Controllerクラスの初期表示メソッド内でServiceクラスのメソッドを呼び出し、モデルに格納して画面に渡す。
- 実装方針・詳細 5
　HTMLでデータベースから取得した情報の分類名のみを表形式で表示。